### PR TITLE
Update to the new floating-point literal API.

### DIFF
--- a/lib/wasm2cretonne/src/code_translator.rs
+++ b/lib/wasm2cretonne/src/code_translator.rs
@@ -189,8 +189,8 @@ pub fn translate_function_body(parser: &mut Parser,
             let val = match ty {
                 I32 => builder.ins().iconst(ty, 0),
                 I64 => builder.ins().iconst(ty, 0),
-                F32 => builder.ins().f32const(Ieee32::new(0.0)),
-                F64 => builder.ins().f64const(Ieee64::new(0.0)),
+                F32 => builder.ins().f32const(Ieee32::with_bits(0)),
+                F64 => builder.ins().f64const(Ieee64::with_bits(0)),
                 _ => panic!("should not happen"),
             };
             for _ in 0..loc_count {

--- a/lib/wasm2cretonne/src/runtime/dummy.rs
+++ b/lib/wasm2cretonne/src/runtime/dummy.rs
@@ -29,8 +29,8 @@ impl WasmRuntime for DummyRuntime {
         match glob.ty {
             I32 => builder.ins().iconst(glob.ty, -1),
             I64 => builder.ins().iconst(glob.ty, -1),
-            F32 => builder.ins().f32const(Ieee32::new(-1.0)),
-            F64 => builder.ins().f64const(Ieee64::new(-1.0)),
+            F32 => builder.ins().f32const(Ieee32::with_bits(0xbf800000)), // -1.0
+            F64 => builder.ins().f64const(Ieee64::with_bits(0xbff0000000000000)), // -1.0
             _ => panic!("should not happen"),
         }
     }

--- a/lib/wasm2cretonne/src/translation_utils.rs
+++ b/lib/wasm2cretonne/src/translation_utils.rs
@@ -1,7 +1,6 @@
 ///! Helper functions and structures for the translation.
 use wasmparser;
 use cretonne;
-use std::mem;
 use std::u32;
 use code_translator;
 use module_translator;
@@ -103,12 +102,12 @@ pub fn type_to_type(ty: &wasmparser::Type) -> Result<cretonne::ir::Type, ()> {
 
 /// Turns a `wasmparser` `f32` into a `Cretonne` one.
 pub fn f32_translation(x: wasmparser::Ieee32) -> cretonne::ir::immediates::Ieee32 {
-    cretonne::ir::immediates::Ieee32::new(unsafe { mem::transmute(x.bits()) })
+    cretonne::ir::immediates::Ieee32::with_bits(x.bits())
 }
 
 /// Turns a `wasmparser` `f64` into a `Cretonne` one.
 pub fn f64_translation(x: wasmparser::Ieee64) -> cretonne::ir::immediates::Ieee64 {
-    cretonne::ir::immediates::Ieee64::new(unsafe { mem::transmute(x.bits()) })
+    cretonne::ir::immediates::Ieee64::with_bits(x.bits())
 }
 
 /// Translate a `wasmparser` type into its `Cretonne` equivalent, when possible


### PR DESCRIPTION
This updates to [recent Cretonne API changes](https://github.com/stoklund/cretonne/pull/130).

This eliminates two instances of unsafe code.